### PR TITLE
feat: 네이버 컨벤션 적용 #18

### DIFF
--- a/conventions/naver-intellij-formatter.xml
+++ b/conventions/naver-intellij-formatter.xml
@@ -1,0 +1,62 @@
+<code_scheme name="Naver-coding-convention-v1.2">
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1" />
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <emptyLine />
+            <package name="" withSubpackages="true" static="true" />
+            <emptyLine />
+            <package name="java" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javax" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="org" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="net" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.nhncorp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.navercorp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com.naver" withSubpackages="true" static="false" />
+            <emptyLine />
+        </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="120" />
+    <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
+    <option name="JD_KEEP_EMPTY_LINES" value="false" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JAVA">
+        <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
+        <option name="LINE_COMMENT_ADD_SPACE" value="true" />
+        <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+        <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+        <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+        <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+        <option name="THROWS_LIST_WRAP" value="5" />
+        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+        <option name="BINARY_OPERATION_WRAP" value="1" />
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+        <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="USE_TAB_CHARACTER" value="true" />
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
## 관련 이슈
- Closes #18 

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 코드 컨벤션 적용 전

- **to-be**
  - 네이버 코드 컨벤션으로 적용 코드 추가
  - 코멘트에 설정 방식 추가

## 코멘트
- 1. 설정 - code style (코드스타일) - java(자바) - 구성표 - 구성표가져오기 - IntellijIDEA 코드스타일 XML - 현재 프로젝트의 컨벤션 xml 위치 설정
![image](https://github.com/user-attachments/assets/71d215aa-857b-4796-96b9-7ed585610de6)
![image](https://github.com/user-attachments/assets/ec39578a-c5f3-408a-be95-0be7504a5e90)

- 2. 설정 - 저장시액션 - 코드서식다시지정, import문 최적화 체크
![image](https://github.com/user-attachments/assets/d6a77c96-3983-4900-8cf2-6568ff761a66)
