### PR TITLE
Feature/#52 user delete event

### DIFF
--- a/achivement-service/src/main/java/com/_42195km/msa/achievementservice/domain/model/Achievement.java
+++ b/achivement-service/src/main/java/com/_42195km/msa/achievementservice/domain/model/Achievement.java
@@ -3,6 +3,7 @@ package com._42195km.msa.achievementservice.domain.model;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.UuidGenerator;
@@ -69,5 +70,11 @@ public class Achievement extends BaseEntity {
 			.criteriaInequality(CriteriaInequality.valueOf(createAchievementCommandDto.getCriteriaType()))
 			.achievementUsers(new HashSet<>())
 			.build();
+	}
+
+	public Set<AchievementUser> getAchievementUsers() {
+		return achievementUsers.stream().filter(achievementUser -> {
+			return !achievementUser.isDeleted();
+		}).collect(Collectors.toSet());
 	}
 }

--- a/achivement-service/src/main/java/com/_42195km/msa/achievementservice/domain/repository/AchievementUserRepository.java
+++ b/achivement-service/src/main/java/com/_42195km/msa/achievementservice/domain/repository/AchievementUserRepository.java
@@ -1,5 +1,6 @@
 package com._42195km.msa.achievementservice.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -11,4 +12,5 @@ import com._42195km.msa.achievementservice.domain.model.AchievementUser;
 public interface AchievementUserRepository {
 	Page<Achievement> search(UUID userId, Pageable pageable);
 	AchievementUser save(AchievementUser achievementUser);
+	List<AchievementUser> findByUserId(UUID userId);
 }

--- a/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/messaging/in/DeleteUserEventConsumer.java
+++ b/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/messaging/in/DeleteUserEventConsumer.java
@@ -1,0 +1,47 @@
+package com._42195km.msa.achievementservice.infrastructure.messaging.in;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com._42195km.msa.achievementservice.domain.model.AchievementUser;
+import com._42195km.msa.achievementservice.domain.repository.AchievementRepository;
+import com._42195km.msa.achievementservice.domain.repository.AchievementUserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DeleteUserEventConsumer {
+	private final ObjectMapper objectMapper;
+	private final AchievementUserRepository achievementUserRepository;
+
+	public DeleteUserEventConsumer(ObjectMapper objectMapper,
+		AchievementUserRepository achievementUserRepository) {
+		Logger logger = LoggerFactory.getLogger(DeleteUserEventConsumer.class);
+		logger.info("consumer created");
+
+		this.objectMapper = objectMapper;
+		this.achievementUserRepository = achievementUserRepository;
+	}
+
+	@KafkaListener(topics = "delete-user", groupId = "runningrecord-group")
+	public void handleDeleteUserEvent(Map<String, Object> eventMap) {
+		Logger logger = LoggerFactory.getLogger(DeleteUserEventConsumer.class);
+
+		DeleteUserEventDto deleteUserEventDto = objectMapper.convertValue(eventMap, DeleteUserEventDto.class);
+		UUID userId = deleteUserEventDto.getUserId();
+
+		List<AchievementUser> achievementUsers = achievementUserRepository.findByUserId(userId);
+		achievementUsers.forEach(achievementUser -> {
+			achievementUser.setDeleted();
+			logger.info("deleted user {}", achievementUser.getUserId());
+		});
+	}
+}

--- a/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/messaging/in/DeleteUserEventDto.java
+++ b/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/messaging/in/DeleteUserEventDto.java
@@ -1,0 +1,16 @@
+package com._42195km.msa.achievementservice.infrastructure.messaging.in;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteUserEventDto {
+	private UUID userId;
+}

--- a/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/persistence/AchievementUserJpaRepository.java
+++ b/achivement-service/src/main/java/com/_42195km/msa/achievementservice/infrastructure/persistence/AchievementUserJpaRepository.java
@@ -1,5 +1,6 @@
 package com._42195km.msa.achievementservice.infrastructure.persistence;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -16,4 +17,7 @@ public interface AchievementUserJpaRepository extends AchievementUserRepository,
 	@Override
 	@Query("SELECT au.achievement FROM AchievementUser au WHERE au.userId = :userId")
 	Page<Achievement> search(@Param("userId") UUID userId, Pageable pageable);
+
+	@Override
+	List<AchievementUser> findByUserId(UUID userId);
 }

--- a/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/RunningrecordServiceApplication.java
+++ b/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/RunningrecordServiceApplication.java
@@ -3,7 +3,7 @@ package com._42195km.msa.runningrecordservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com._42195km.msa.runningrecordservice", "com._42195km.msa.common"})
 public class RunningrecordServiceApplication {
 
     public static void main(String[] args) {

--- a/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/infrastructure/messaging/in/DeleteUserEventConsumer.java
+++ b/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/infrastructure/messaging/in/DeleteUserEventConsumer.java
@@ -1,0 +1,45 @@
+package com._42195km.msa.runningrecordservice.infrastructure.messaging.in;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com._42195km.msa.common.BaseEntity;
+import com._42195km.msa.runningrecordservice.domain.model.RunningRecord;
+import com._42195km.msa.runningrecordservice.domain.repository.RunningRecordRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DeleteUserEventConsumer {
+	private final ObjectMapper objectMapper;
+	private final RunningRecordRepository runningRecordRepository;
+
+	public DeleteUserEventConsumer(ObjectMapper objectMapper,
+		RunningRecordRepository runningRecordRepository) {
+		Logger logger = LoggerFactory.getLogger(DeleteUserEventConsumer.class);
+		logger.info("consumer created");
+
+		this.objectMapper = objectMapper;
+		this.runningRecordRepository = runningRecordRepository;
+	}
+
+	@KafkaListener(topics = "delete-user", groupId = "runningrecord-group")
+	public void handleDeleteUserEvent(Map<String, Object> eventMap) {
+		DeleteUserEventDto deleteUserEventDto = objectMapper.convertValue(eventMap, DeleteUserEventDto.class);
+		UUID userId = deleteUserEventDto.getUserId();
+
+		List<RunningRecord> runningRecords = runningRecordRepository.findByUserId(userId);
+		runningRecords.forEach(runningRecord -> {
+			runningRecord.setDeleted();
+			log.info("deleted Running Record: {}", runningRecord.getId());
+		});
+	}
+}

--- a/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/infrastructure/messaging/in/DeleteUserEventDto.java
+++ b/runningrecord-service/src/main/java/com/_42195km/msa/runningrecordservice/infrastructure/messaging/in/DeleteUserEventDto.java
@@ -1,0 +1,16 @@
+package com._42195km.msa.runningrecordservice.infrastructure.messaging.in;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteUserEventDto {
+	private UUID userId;
+}

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/com/_42195km/msa/user/application/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/_42195km/msa/user/application/service/UserServiceImpl.java
@@ -18,6 +18,7 @@ import com._42195km.msa.user.application.dto.response.SearchUserResponseDto;
 import com._42195km.msa.user.application.dto.response.UpdateUserResponseDto;
 import com._42195km.msa.user.application.exception.UserException;
 import com._42195km.msa.user.domain.model.User;
+import com._42195km.msa.user.infrastructure.messaging.out.DeleteUserEventProducer;
 import com._42195km.msa.user.infrastructure.persistence.UserRepositoryImpl;
 
 import jakarta.validation.Valid;
@@ -32,6 +33,7 @@ public class UserServiceImpl implements UserService {
 
 	private final PasswordEncoder passwordEncoder;
 	private final UserRepositoryImpl userRepositoryImpl;
+	private final DeleteUserEventProducer deleteUserEventProducer;
 
 	@Override
 	@Transactional
@@ -107,6 +109,8 @@ public class UserServiceImpl implements UserService {
 		User targetUser = findUserById(userId);
 
 		targetUser.setDeleted();
+
+		deleteUserEventProducer.sendDeleteUserEvent(targetUser.getId());
 	}
 
 	@Transactional
@@ -116,6 +120,8 @@ public class UserServiceImpl implements UserService {
 		User targetUser = findUserById(userId);
 
 		targetUser.setDeleted();
+
+		deleteUserEventProducer.sendDeleteUserEvent(targetUser.getId());
 	}
 
 	private User findUserById(UUID userId) {

--- a/user-service/src/main/java/com/_42195km/msa/user/infrastructure/config/KafkaConfig.java
+++ b/user-service/src/main/java/com/_42195km/msa/user/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,41 @@
+package com._42195km.msa.user.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String kafkaBootstrapServers;
+
+	@Value("${spring.kafka.consumer.group-id}")
+	private String groupId;
+
+	@Bean
+	public <T> ProducerFactory<String, T> producerFactory() {
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers);
+		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+		return new DefaultKafkaProducerFactory<>(props);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/user-service/src/main/java/com/_42195km/msa/user/infrastructure/messaging/out/DeleteUserEventDto.java
+++ b/user-service/src/main/java/com/_42195km/msa/user/infrastructure/messaging/out/DeleteUserEventDto.java
@@ -1,0 +1,16 @@
+package com._42195km.msa.user.infrastructure.messaging.out;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteUserEventDto {
+	private UUID userId;
+}

--- a/user-service/src/main/java/com/_42195km/msa/user/infrastructure/messaging/out/DeleteUserEventProducer.java
+++ b/user-service/src/main/java/com/_42195km/msa/user/infrastructure/messaging/out/DeleteUserEventProducer.java
@@ -1,0 +1,28 @@
+package com._42195km.msa.user.infrastructure.messaging.out;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DeleteUserEventProducer {
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private Logger logger = LoggerFactory.getLogger(DeleteUserEventProducer.class);
+
+	public DeleteUserEventProducer(KafkaTemplate<String, Object> kafkaTemplate) {
+		this.kafkaTemplate = kafkaTemplate;
+		logger.info("Created DeleteUserEventProducer");
+	}
+
+	public void sendDeleteUserEvent(UUID userId) {
+		logger.info("deleted user {}", userId);
+		DeleteUserEventDto deleteUserEventDto = new DeleteUserEventDto(userId);
+		kafkaTemplate.send("delete-user", deleteUserEventDto);
+	}
+}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -10,6 +10,12 @@ spring:
     group:
       local: local, key
     active: ${ACTIVE_VAL}
+  kafka:
+    url: localhost:9092
+    bootstrap-servers: localhost:9092
+    consumer:
+      auto-offset-reset: earliest
+      group-id: user-group
 eureka:
   client:
     service-url:


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**
  - (변경 후 설명을 여기에 작성)

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
    - 사용자가 삭제 또는 차단될 때 관련 서비스에 사용자 삭제 이벤트가 전파되어, 연관된 업적 및 러닝 레코드가 함께 삭제 처리됩니다.
    - Kafka 메시지 브로커 연동을 통해 사용자 삭제 이벤트가 각 서비스로 전달됩니다.
    - 사용자 서비스에 Kafka 설정 및 메시지 발행 기능이 추가되었습니다.

- **버그 수정**
    - 없음.

- **문서화**
    - 없음.

- **기타**
    - 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->