### PR TITLE
Feature/#56 : @UserInfo 애노테이션 추가

### DIFF
--- a/common/src/main/java/com/_42195km/msa/common/config/WebConfig.java
+++ b/common/src/main/java/com/_42195km/msa/common/config/WebConfig.java
@@ -1,11 +1,20 @@
 package com._42195km.msa.common.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com._42195km.msa.common.resolver.UserInfoArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+	private final UserInfoArgumentResolver userInfoArgumentResolver;
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
@@ -14,5 +23,10 @@ public class WebConfig implements WebMvcConfigurer {
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
 			.allowedHeaders("*")
 			.allowCredentials(true);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(userInfoArgumentResolver);
 	}
 }

--- a/common/src/main/java/com/_42195km/msa/common/resolver/UserInfo.java
+++ b/common/src/main/java/com/_42195km/msa/common/resolver/UserInfo.java
@@ -1,0 +1,11 @@
+package com._42195km.msa.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserInfo {
+}

--- a/common/src/main/java/com/_42195km/msa/common/resolver/UserInfoArgumentResolver.java
+++ b/common/src/main/java/com/_42195km/msa/common/resolver/UserInfoArgumentResolver.java
@@ -1,0 +1,38 @@
+package com._42195km.msa.common.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Component
+public class UserInfoArgumentResolver implements HandlerMethodArgumentResolver {
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String USER_ROLE_HEADER = "X-User-Role";
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(UserInfo.class)
+			&& parameter.getParameterType().equals(UserInfoDto.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+
+		String userId = request.getHeader(USER_ID_HEADER);
+		String role = request.getHeader(USER_ROLE_HEADER);
+
+		if (userId == null && role == null) {
+			return UserInfoDto.empty();
+		}
+
+		return UserInfoDto.of(userId, role);
+
+	}
+}

--- a/common/src/main/java/com/_42195km/msa/common/resolver/UserInfoDto.java
+++ b/common/src/main/java/com/_42195km/msa/common/resolver/UserInfoDto.java
@@ -1,0 +1,27 @@
+package com._42195km.msa.common.resolver;
+
+import java.util.UUID;
+
+public record UserInfoDto(
+	UUID userId,
+	String role
+) {
+	public static UserInfoDto of(String userId, String role) {
+		if (userId == null || role == null) {
+			return empty();
+		}
+		return parseUserInfo(userId, role);
+	}
+
+	public static UserInfoDto empty() {
+		return new UserInfoDto(null, null);
+	}
+
+	private static UserInfoDto parseUserInfo(String userId, String role) {
+		try {
+			return new UserInfoDto(UUID.fromString(userId), role);
+		} catch (IllegalArgumentException e) {
+			return empty();
+		}
+	}
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #56 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 로그인 사용자 정보를 컨트롤러에 파라미터로 넣을 수 없었음
- **to-be**
  - 애노테이션으로 관련 기능 지원

## 코멘트
- 컨트롤러에 `@UserIfno UserInfoDto userinfo`  파라미터 추가하고 
코드에서 `userinfo.userId` 등으로 활용하면 됨 
`@AuthenticalPrincipal` 과 비슷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 컨트롤러 메서드에서 `@UserInfo` 어노테이션을 사용해 HTTP 헤더(`X-User-Id`, `X-User-Role`) 기반 사용자 정보를 자동으로 주입받을 수 있습니다.

- **개선 사항**
    - 사용자 정보 주입을 위한 어노테이션(`@UserInfo`) 및 데이터 객체가 추가되었습니다.  
    - 사용자 정보가 없는 경우에도 안전하게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->