### PR TITLE
refactor: slack message 전송 executorservice 추가

### DIFF
--- a/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/config/ThreadPoolConfig.java
+++ b/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/config/ThreadPoolConfig.java
@@ -1,0 +1,15 @@
+package com._42195km.alertservice.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Configuration
+public class ThreadPoolConfig {
+    @Bean("slackApiExecutor")
+    public ExecutorService slackApiExecutor() {
+        return Executors.newFixedThreadPool(50);
+    }
+}

--- a/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/messaging/in/AchievementKafkaConsumer.java
+++ b/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/messaging/in/AchievementKafkaConsumer.java
@@ -5,6 +5,7 @@ import com._42195km.alertservice.infrastructure.messaging.dto.AchieveEventDto;
 import com._42195km.alertservice.infrastructure.messaging.dto.CompetitionEventDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
@@ -14,12 +15,15 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class AchievementKafkaConsumer {
 
+    @Qualifier("slackApiExecutor")
+    private final ExecutorService executorService;
     private final AlertContext context;
     private final AchievementStrategyImpl achievementStrategy;
 
@@ -28,7 +32,7 @@ public class AchievementKafkaConsumer {
         List<CompletableFuture<Void>> futures = eventMaps.stream()
                 .map(eventMap -> CompletableFuture.runAsync(() -> {
                     context.sendMessage(eventMap, achievementStrategy, AchieveEventDto.class);
-                }))
+                }, executorService))
                 .toList();
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();

--- a/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/messaging/in/CompetitionKafkaConsumer.java
+++ b/alert-service/src/main/java/com/_42195km/alertservice/infrastructure/messaging/in/CompetitionKafkaConsumer.java
@@ -9,12 +9,15 @@ import com._42195km.msa.common.exception.CustomBusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
@@ -22,6 +25,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 public class CompetitionKafkaConsumer {
 
+    @Qualifier("slackApiExecutor")
+    private final ExecutorService executorService;
     private final AlertContext context;
     private final CompetitionStrategyImpl competitionStrategy;
 
@@ -31,7 +36,7 @@ public class CompetitionKafkaConsumer {
         List<CompletableFuture<Void>> futures = eventMaps.stream()
                 .map(eventMap -> CompletableFuture.runAsync(() -> {
                     context.sendMessage(eventMap, competitionStrategy, CompetitionEventDto.class);
-                }))
+                }, executorService))
                 .toList();
 
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();


### PR DESCRIPTION
## 관련 이슈
- Closes #

## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - (변경 전 설명을 여기에 작성)

- **to-be**
  - slack message 전송 executorservice 추가

## 코멘트
- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Slack 알림 처리를 위한 전용 스레드 풀 도입으로, 알림 메시지 전송이 더욱 안정적으로 비동기 처리됩니다.

- **버그 수정**
	- Kafka 이벤트 처리 시 비동기 작업이 전용 스레드 풀에서 실행되어, 시스템 리소스 관리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->